### PR TITLE
Create .ps1 file to package .pk3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+compiled-pk3

--- a/compile.ps1
+++ b/compile.ps1
@@ -34,16 +34,16 @@ if (Test-Path $pk3SavePath) {
 Write-Host "Archiving..."
 Compress-Archive -Path $itemsToArchive.FullName -DestinationPath $finalSavePath -CompressionLevel 'NoCompression'
 Write-Host "Done!"
-
 Write-Host ""
+
 Write-Host "Renaming to .pk3..."
 Rename-Item -Path $finalSavePath -NewName $pk3Name
 Write-Host "Done!"
-
 Write-Host ""
+
 Write-Host ".pk3 file created at: "
 Write-Host $pk3SavePath
-
 Write-Host ""
+
 Write-Host "Press any key to close this powershell window..."
 $key = [System.Console]::ReadKey()

--- a/compile.ps1
+++ b/compile.ps1
@@ -7,7 +7,7 @@ $savePath = Join-Path $currentFolder $compiledFolderName
 
 if (-not (Test-Path -Path $savePath -PathType Container)) {
     Write-Host "Creating ""$compiledFolderName"" folder..."
-    New-Item -ItemType Directory -Path $savePath -Force
+    New-Item -ItemType Directory -Path $savePath -Force | Out-Null
     Write-Host "Done!`n"
 }
 

--- a/compile.ps1
+++ b/compile.ps1
@@ -1,0 +1,41 @@
+$archiveName = "TobyAccessibilityMod.zip"
+$pk3Name = "TobyAccessibilityMod.pk3"
+$compiledFolderName = "compiled-pk3"
+
+$currentFolder = Get-Item -LiteralPath ".\"
+$savePath = Join-Path $currentFolder $compiledFolderName
+$finalSavePath = Join-Path $savePath $archiveName
+$pk3SavePath = Join-Path $savePath $pk3Name
+
+$excludeList = @(".git", ".gitignore", $MyInvocation.MyCommand.Name, $compiledFolderName)
+$itemsToArchive = Get-ChildItem -Path $folderPath | Where-Object { $_.Name -notin $excludeList }
+
+if (Test-Path $finalSavePath) {
+    Write-Host "Removing old .zip file..."
+    Remove-Item $finalSavePath -Force
+    Write-Host "Done!"
+    Write-Host ""
+}
+if (Test-Path $pk3SavePath) {
+    Write-Host "Removing old .pk3 file..."
+    Remove-Item $pk3SavePath -Force
+    Write-Host "Done!"
+    Write-Host ""
+}
+
+Write-Host "Archiving..."
+Compress-Archive -Path $itemsToArchive.FullName -DestinationPath $finalSavePath -CompressionLevel 'NoCompression'
+Write-Host "Done!"
+
+Write-Host ""
+Write-Host "Renaming to .pk3..."
+Rename-Item -Path $finalSavePath -NewName $pk3Name
+Write-Host "Done!"
+
+Write-Host ""
+Write-Host ".pk3 file created at: "
+Write-Host $pk3SavePath
+
+Write-Host ""
+Write-Host "Press any key to close this powershell window..."
+$key = [System.Console]::ReadKey()

--- a/compile.ps1
+++ b/compile.ps1
@@ -4,6 +4,14 @@ $compiledFolderName = "compiled-pk3"
 
 $currentFolder = Get-Item -LiteralPath ".\"
 $savePath = Join-Path $currentFolder $compiledFolderName
+
+if (-not (Test-Path -Path $savePath -PathType Container)) {
+    Write-Host "Creating ""$compiledFolderName"" folder..."
+    New-Item -ItemType Directory -Path $savePath -Force
+    Write-Host "Done!"
+    Write-Host ""
+}
+
 $finalSavePath = Join-Path $savePath $archiveName
 $pk3SavePath = Join-Path $savePath $pk3Name
 

--- a/compile.ps1
+++ b/compile.ps1
@@ -8,8 +8,7 @@ $savePath = Join-Path $currentFolder $compiledFolderName
 if (-not (Test-Path -Path $savePath -PathType Container)) {
     Write-Host "Creating ""$compiledFolderName"" folder..."
     New-Item -ItemType Directory -Path $savePath -Force
-    Write-Host "Done!"
-    Write-Host ""
+    Write-Host "Done!`n"
 }
 
 $finalSavePath = Join-Path $savePath $archiveName
@@ -21,29 +20,24 @@ $itemsToArchive = Get-ChildItem -Path $folderPath | Where-Object { $_.Name -noti
 if (Test-Path $finalSavePath) {
     Write-Host "Removing old .zip file..."
     Remove-Item $finalSavePath -Force
-    Write-Host "Done!"
-    Write-Host ""
+    Write-Host "Done!`n"
 }
 if (Test-Path $pk3SavePath) {
     Write-Host "Removing old .pk3 file..."
     Remove-Item $pk3SavePath -Force
-    Write-Host "Done!"
-    Write-Host ""
+    Write-Host "Done!`n"
 }
 
 Write-Host "Archiving..."
 Compress-Archive -Path $itemsToArchive.FullName -DestinationPath $finalSavePath -CompressionLevel 'NoCompression'
-Write-Host "Done!"
-Write-Host ""
+Write-Host "Done!`n"
 
 Write-Host "Renaming to .pk3..."
 Rename-Item -Path $finalSavePath -NewName $pk3Name
-Write-Host "Done!"
-Write-Host ""
+Write-Host "Done!`n"
 
 Write-Host ".pk3 file created at: "
-Write-Host $pk3SavePath
-Write-Host ""
+Write-Host "$pk3SavePath`n"
 
 Write-Host "Press any key to close this powershell window..."
 $key = [System.Console]::ReadKey()

--- a/zscript/Utils/Toby_WadsUtils.zs
+++ b/zscript/Utils/Toby_WadsUtils.zs
@@ -17,6 +17,7 @@ class Toby_WadsUtils
 
             splitTokens.Clear();
             lumpFileNameWithExtension.Split(splitTokens, ".");
+            if (splitTokens.Size() == 0) { continue; }
             string lumpOnlyFileName = splitTokens[0];
             if (splitTokens.Size() > 1)
             {


### PR DESCRIPTION
Here I've created powershell script that will package .pk3 files for you.
You can right click compile.ps1, select "Run with powershell" and it will create TobyAccessibilityMod.pk3 file in "compiled-pk3" folder.

"compiled-pk3" folder will be created if it does not exist.

Existing "TobyAccessibilityMod.pk3" and "TobyAccessibilityMod.zip" will be removed beforehand if they are found in "compiled-pk3" folder.

I've also added .gitignore file so that git would ignore "compiled-pk3" folder.