### PR TITLE
Version 7 Update 1/17/2024

### DIFF
--- a/decorate/DEC_AMMO.dec
+++ b/decorate/DEC_AMMO.dec
@@ -4,7 +4,7 @@ ACTOR Clip_Toby : CustomInventory replaces Clip
 {
 	Inventory.PickupMessage "$GOTCLIP"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "Clip_ID"
+	Inventory.PickupFlash "Clip_ID2"
 States
 	{
 	Spawn:
@@ -24,7 +24,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -33,7 +33,7 @@ ACTOR Clip_Toby_Zombie : CustomInventory //Ammo dropped by Pistol Dude
 {
 	Inventory.PickupMessage "$GOTCLIP"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "Clip_ID"
+	Inventory.PickupFlash "Clip_ID2"
 States
 	{
 	Spawn:
@@ -53,7 +53,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -104,13 +104,47 @@ actor Clip_ID
 	}
 }
 
+actor Clip_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ClipAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ClipAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ClipAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/clip", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 // Clip box ----------------------------------------------------------------
 
 ACTOR ClipBox_Toby : CustomInventory replaces ClipBox
 {
 	Inventory.PickupMessage "$GOTCLIPBOX"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "ClipBox_ID"
+	Inventory.PickupFlash "ClipBox_ID2"
 States
 	{
 	Spawn:
@@ -130,7 +164,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -179,6 +213,40 @@ actor ClipBox_ID
 		TNT1 A 8 A_PlaySoundEx("ann/ammo", "WeaponSlot7", 0, 2)
 		Stop
 	}
+}
+
+actor ClipBox_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ClipBoxAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ClipBoxAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ClipBoxAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/ammo", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 ACTOR AmmoPickupChecker_Clip
@@ -311,7 +379,7 @@ ACTOR RocketAmmo_Toby : CustomInventory replaces RocketAmmo
 {
 	Inventory.PickupMessage "$GOTROCKET"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "Rocket_ID"
+	Inventory.PickupFlash "Rocket_ID2"
 States
 	{
 	Spawn:
@@ -331,7 +399,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -382,13 +450,47 @@ actor Rocket_ID
 	}
 }
 
+actor Rocket_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("RocketAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("RocketAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor RocketAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/rocket", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 // Rocket box --------------------------------------------------------------
 
 ACTOR RocketBox_Toby : CustomInventory replaces RocketBox
 {
 	Inventory.PickupMessage "$GOTROCKBOX"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "RocketBox_ID"
+	Inventory.PickupFlash "RocketBox_ID2"
 States
 	{
 	Spawn:
@@ -408,7 +510,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -457,6 +559,40 @@ actor RocketBox_ID
 		TNT1 A 8 A_PlaySoundEx("ann/rocketbox", "WeaponSlot7", 0, 2)
 		Stop
 	}
+}
+
+actor RocketBox_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("RocketBoxAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("RocketBoxAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor RocketBoxAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/rocketbox", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 ACTOR AmmoPickupChecker_Rocket
@@ -589,7 +725,7 @@ ACTOR Cell_Toby : CustomInventory replaces Cell
 {
 	Inventory.PickupMessage "$GOTCELL"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "Cell_ID"
+	Inventory.PickupFlash "Cell_ID2"
 States
 	{
 	Spawn:
@@ -609,7 +745,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -660,13 +796,47 @@ actor Cell_ID
 	}
 }
 
+actor Cell_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("CellAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("CellAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor CellAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/cell", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 // Cell pack ---------------------------------------------------------------
 
 ACTOR CellPack_Toby : CustomInventory replaces CellPack
 {
 	Inventory.PickupMessage "$GOTCELLBOX"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "CellPack_ID"
+	Inventory.PickupFlash "CellPack_ID2"
 States
 	{
 	Spawn:
@@ -686,7 +856,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -735,6 +905,40 @@ actor CellPack_ID
 		TNT1 A 8 A_PlaySoundEx("ann/cellpack", "WeaponSlot7", 0, 2)
 		Stop
 	}
+}
+
+actor CellPack_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("CellPackAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("CellPackAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor CellPackAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/cellpack", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 ACTOR AmmoPickupChecker_Cell
@@ -867,7 +1071,7 @@ ACTOR Shell_Toby : CustomInventory replaces Shell
 {
 	Inventory.PickupMessage "$GOTSHELLS"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "Shells_ID"
+	Inventory.PickupFlash "Shells_ID2"
 States
 	{
 	Spawn:
@@ -887,7 +1091,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -938,13 +1142,47 @@ actor Shells_ID
 	}
 }
 
+actor Shells_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ShellsAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ShellsAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ShellsAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/shells", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 // Shell box ---------------------------------------------------------------
 
 ACTOR ShellBox_Toby : CustomInventory replaces ShellBox
 {
 	Inventory.PickupMessage "$GOTSHELLBOX"
 	Inventory.PickupSound "misc/ammo_pkup"
-	Inventory.PickupFlash "ShellBox_ID"
+	Inventory.PickupFlash "ShellBox_ID2"
 States
 	{
 	Spawn:
@@ -964,7 +1202,7 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
@@ -1013,6 +1251,40 @@ actor ShellBox_ID
 		TNT1 A 8 A_PlaySoundEx("ann/shellbox", "WeaponSlot7", 0, 2)
 		Stop
 	}
+}
+
+actor ShellBox_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ShellBoxAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ShellBoxAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ShellBoxAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/shellbox", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 ACTOR AmmoPickupChecker_Shell
@@ -1144,7 +1416,7 @@ ACTOR AmmoPickupChecker_ShellBox
 ACTOR Backpack_TO : Backpack replaces Backpack
 {
 	Inventory.PickupSound "misc/bpack"
-	Inventory.PickupFlash "BPack_ID"
+	Inventory.PickupFlash "BPack_ID2"
 	States
 	{
 	Spawn:
@@ -1185,6 +1457,40 @@ actor BPack_ID
 		TNT1 A 8 A_PlaySoundEx("ann/backpack", "WeaponSlot7", 0, 2)
 		Stop
 	}
+}
+
+actor BPack_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("BPackAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("BPackAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor BPackAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/backpack", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 ACTOR BPackPickupChecker

--- a/decorate/DEC_ARMR.dec
+++ b/decorate/DEC_ARMR.dec
@@ -7,7 +7,7 @@ Actor ArmorBonus_TO : BasicArmorBonus replaces ArmorBonus
 	Inventory.Pickupmessage "$GOTARMBONUS"
 	Inventory.PickupSound "armor/bonus"
 	Inventory.Icon "BON2A0"
-	Inventory.PickupFlash "ArmorBonus_ID"
+	Inventory.PickupFlash "ArmorBonus_ID2"
 	Armor.Savepercent 33.335
 	Armor.Saveamount 1
 	Armor.Maxsaveamount 200
@@ -74,6 +74,40 @@ actor ArmorBonus_ID
 		TNT1 A 8 A_PlaySoundEx("ann/armorbonus", "WeaponSlot7", 0, 2)
 		Stop
 	}
+}
+
+actor ArmorBonus_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ArmorBonusAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ArmorBonusAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ArmorBonusAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/armorbonus", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 // Green armor --------------------------------------------------------------
@@ -151,7 +185,7 @@ ACTOR GreenArmor_Pickup : CustomInventory replaces GreenArmor
 	Height 16
 	Inventory.Pickupmessage "$GOTARMOR"
 	Inventory.PickupSound "armor/green"
-	Inventory.PickupFlash "Armor_ID"
+	Inventory.PickupFlash "Armor_ID2"
 States
 	{
 	Spawn:
@@ -177,9 +211,43 @@ States
 		TNT1 A 1 A_GiveInventory("GreenArmor_TO", 1)
 		Stop
 	NoPickup:
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot5", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot5", 0, 1)
 		Fail
 	}
+}
+
+actor Armor_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ArmorAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ArmorAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ArmorAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/armor", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 // Blue armor ---------------------------------------------------------------
@@ -259,7 +327,7 @@ ACTOR BlueArmor_Pickup : CustomInventory replaces BlueArmor
 	Height 16
 	Inventory.Pickupmessage "$GOTMEGA"
 	Inventory.PickupSound "armor/blue"
-	Inventory.PickupFlash "Armor2_ID"
+	Inventory.PickupFlash "Armor2_ID2"
 States
 	{
 	Spawn:
@@ -277,9 +345,43 @@ States
 		TNT1 A 1 A_GiveInventory("BlueArmor_TO", 1)
 		Stop
 	NoPickup:
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot5", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot5", 0, 1)
 		Fail
 	}
+}
+
+actor Armor2_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("Armor2Ann", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("Armor2Ann", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor Armor2Ann : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/armor2", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 //**********************************************************

--- a/decorate/DEC_HLTH.dec
+++ b/decorate/DEC_HLTH.dec
@@ -6,7 +6,7 @@ ACTOR HealthBonus_TO : Health replaces HealthBonus
 	Inventory.MaxAmount 200
 	Inventory.PickupMessage "$GOTHTHBONUS"
 	Inventory.PickupSound "health/bonus"
-	Inventory.PickupFlash "HealthBonus_ID"
+	Inventory.PickupFlash "HealthBonus_ID2"
 	States
 	{
 	Spawn:
@@ -64,6 +64,40 @@ actor HealthBonus_ID
 		TNT1 A 8 A_PlaySoundEx("ann/healthbonus", "WeaponSlot7", 0, 2)
 		Stop
 	}
+}
+
+actor HealthBonus_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("HealthBonusAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("HealthBonusAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor HealthBonusAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/healthbonus", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 	
 // Stimpack -----------------------------------------------------------------
@@ -128,7 +162,7 @@ ACTOR Stimpack_Pickup : CustomInventory replaces Stimpack
 {
 	Inventory.PickupMessage "$GOTSTIM"
 	Inventory.PickupSound "health/stim"
-	Inventory.PickupFlash "Stimpack_ID"
+	Inventory.PickupFlash "Stimpack_ID2"
 States
 	{
 	Spawn:
@@ -142,9 +176,43 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
+}
+
+actor Stimpack_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("StimpackAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("StimpackAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor StimpackAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/stimpack", "WeaponSlot7", 0, -1)
+        Stop
+    }
 }
 
 // Medikit -----------------------------------------------------------------
@@ -211,7 +279,7 @@ ACTOR Medikit_Pickup : CustomInventory replaces Medikit
 {
 	Inventory.PickupMessage "$GOTMEDIKIT"
 	Inventory.PickupSound "health/medkit"
-	Inventory.PickupFlash "Medikit_ID"
+	Inventory.PickupFlash "Medikit_ID2"
 States
 	{
 	Spawn:
@@ -225,10 +293,46 @@ States
 		Stop
 	NoPickup:
 		//TNT1 A 1 ACS_NamedExecuteWithResult("InventoryFullBeeper")
-		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 2)
+		TNT1 A 1 A_PlaySoundEx("stat/armor/full", "SoundSlot6", 0, 1)
 		Fail
 	}
 }
+
+actor Medikit_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("MedikitAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("MedikitAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor MedikitAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/medikit", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
+//************************************************************************************
 
 ACTOR HealthPickupChecker
 {

--- a/decorate/DEC_WEAP.dec
+++ b/decorate/DEC_WEAP.dec
@@ -86,7 +86,7 @@ ACTOR Chainsaw_TO : Weapon replaces Chainsaw
     Weapon.UpSound "weapons/sawup"
     Weapon.ReadySound "weapons/sawidle"
     Inventory.PickupSound "weapons/chainsaw_pkup"
-    Inventory.PickupFlash "Chainsaw_ID"
+    Inventory.PickupFlash "Chainsaw_ID2"
     Weapon.SlotNumber 1
     Inventory.PickupMessage "$GOTCHAINSAW"
     Obituary "$OB_MPCHAINSAW"
@@ -133,6 +133,40 @@ actor Chainsaw_ID
     }
 }
 
+actor Chainsaw_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ChainsawAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ChainsawAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ChainsawAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/chainsaw", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 ACTOR Shotgun_TO : DoomWeapon Replaces Shotgun
 {
     Game Doom
@@ -145,7 +179,7 @@ ACTOR Shotgun_TO : DoomWeapon Replaces Shotgun
     AttackSound "weapons/shotgf"
     Weapon.UpSound "weapons/shotup"
     Inventory.PickupSound "weapons/shotgun_pkup"
-    Inventory.PickupFlash "Shotgun_ID"
+    Inventory.PickupFlash "Shotgun_ID2"
     Inventory.PickupMessage "$GOTSHOTGUN"
     Obituary "$OB_MPSHOTGUN"
     Tag "$TAG_SHOTGUN"
@@ -200,6 +234,40 @@ actor Shotgun_ID
     }
 }
 
+actor Shotgun_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ShotgunAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ShotgunAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ShotgunAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/shotgun", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 ACTOR SuperShotgun_TO : DoomWeapon Replaces SuperShotgun
 {
     Game Doom
@@ -209,7 +277,7 @@ ACTOR SuperShotgun_TO : DoomWeapon Replaces SuperShotgun
     Weapon.AmmoGive 8
     Weapon.AmmoType "Shell"
     Weapon.UpSound "weapons/ssgup"
-    Inventory.PickupFlash "SSG_ID"
+    Inventory.PickupFlash "SSG_ID2"
     Inventory.PickupSound "weapons/ssg_pkup"
     Inventory.PickupMessage "$GOTSHOTGUN2"
     Obituary "$OB_MPSSHOTGUN"
@@ -275,6 +343,40 @@ actor SSG_ID
     }
 }
 
+actor SSG_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("SSGAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("SSGAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor SSGAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/ssg", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 ACTOR Chaingun_TO : DoomWeapon Replaces Chaingun
 {
     Game Doom
@@ -286,7 +388,7 @@ ACTOR Chaingun_TO : DoomWeapon Replaces Chaingun
     Weapon.SlotNumber 4
     AttackSound "weapons/chaing"
     Weapon.UpSound "weapons/chaingunup"
-    Inventory.PickupFlash "Chaingun_ID"
+    Inventory.PickupFlash "Chaingun_ID2"
     Inventory.PickupSound "weapons/chaingun_pkup"
     Inventory.PickupMessage "$GOTCHAINGUN"
     Obituary "$OB_MPCHAINGUN"
@@ -344,6 +446,40 @@ actor Chaingun_ID
     }
 }
 
+actor Chaingun_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("ChaingunAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("ChaingunAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor ChaingunAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/chaingun", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 ACTOR RocketLauncher_TO : DoomWeapon Replaces RocketLauncher
 {
     Game Doom
@@ -354,7 +490,7 @@ ACTOR RocketLauncher_TO : DoomWeapon Replaces RocketLauncher
     Weapon.AmmoType "RocketAmmo"
     Weapon.UpSound "weapons/rocketup"
     Inventory.PickupSound "weapons/rocket_pkup"
-    Inventory.PickupFlash "RocketLauncher_ID"
+    Inventory.PickupFlash "RocketLauncher_ID2"
     Weapon.SlotNumber 5
     +WEAPON.NOAUTOFIRE
     Inventory.PickupMessage "$GOTLAUNCHER"
@@ -408,6 +544,40 @@ actor RocketLauncher_ID
     }
 }
 
+actor RocketLauncher_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("RLAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("RLAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor RLAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/rlauncher", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 ACTOR Rocket_TO Replaces Rocket
 {
     Game Doom
@@ -428,7 +598,7 @@ ACTOR Rocket_TO Replaces Rocket
     States
     {
     Spawn:
-        MIS2 A 1 Bright A_ThrowGrenade("RocketTrail_TO", -35, -2, 1)
+        MISL A 1 Bright A_ThrowGrenade("RocketTrail_TO", -35, -2, 1)
         Loop
     Death:
         FRME B 1 Bright A_Explode
@@ -469,7 +639,7 @@ ACTOR PlasmaRifle_TO : DoomWeapon Replaces PlasmaRifle
     Weapon.AmmoGive 40
     Weapon.AmmoType "Cell"
     Weapon.UpSound "weapons/plasmaup"
-    Inventory.PickupFlash "Plasmagun_ID"
+    Inventory.PickupFlash "Plasmagun_ID2"
     Inventory.PickupSound "weapons/plasma_pkup"
     Weapon.SlotNumber 6
     Inventory.PickupMessage "$GOTPLASMA"
@@ -522,6 +692,40 @@ actor Plasmagun_ID
     }
 }
 
+actor Plasmagun_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("PlasmagunAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("PlasmagunAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor PlasmagunAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/plasmagun", "WeaponSlot7", 0, -1)
+        Stop
+    }
+}
+
 ACTOR PlasmaBall_TO replaces PlasmaBall
 {
     Game Doom
@@ -561,7 +765,7 @@ ACTOR BFG9000_TO : DoomWeapon Replaces BFG9000
     Weapon.AmmoGive 40
     Weapon.AmmoType "Cell"
     Weapon.UpSound "weapons/bfgup"
-    Inventory.PickupFlash "BFG_ID"
+    Inventory.PickupFlash "BFG_ID2"
     Inventory.PickupSound "weapons/bfg_pkup"
     Weapon.SlotNumber 7
     +WEAPON.NOAUTOFIRE
@@ -642,6 +846,40 @@ actor BFG_ID
         Goto Death
     Death:
         TNT1 A 8 A_PlaySoundEx("ann/bfg", "WeaponSlot7", 0, 2)
+        Stop
+    }
+}
+
+actor BFG_ID2
+{
+	Radius 11
+	Height 8
+	Speed 0
+    +CORPSE
+    +FLOORCLIP
+    +DONTSPLASH
+	States
+	{
+	Spawn:
+		TNT1 A 8 A_RadiusGive("BFGAnn", 128, RGF_PLAYERS, 1)
+		Goto Death
+	Death:
+		TNT1 A 8 A_RadiusGive("BFGAnn", 128, RGF_PLAYERS, 1)
+		Stop
+	}
+}
+
+Actor BFGAnn : CustomInventory
+{
+ inventory.pickupmessage ""
+ -COUNTITEM
+ States
+ {
+  Spawn: 
+       TNT1 A 1
+       Loop
+ Pickup:
+		TNT1 A 1 A_PlaySoundEx("ann/bfg", "WeaponSlot7", 0, -1)
         Stop
     }
 }


### PR DESCRIPTION
Updates:
- Modified the way the announcer is triggered when the player picks up items and weapons. I changed the Pickup Flash actor and modified the attenuation of the "Full" sound.

While testing a multiplayer game using bots, I was able to hear exactly what the bot was picking up even when it was far away from my position. I altered the way the player would hear the announcer so the only time you'll hear him is if you are picking something up and not another player.

One thing to note, though, during a multiplayer game, whether it be Co-Op or Deathmatch, whenever a player picks up a weapon, the weapon stays on the floor and there's no announcer voice. I may consider modifying the pickup sounds OR Weapon-Up sounds to include the announcer voice in it.