### PR TITLE
Toby V7 Updates 1/31/2024

### DIFF
--- a/KEYCONF.txt
+++ b/KEYCONF.txt
@@ -35,7 +35,7 @@ alias godmode "iddqd; give GodModeGiver"
 addmenukey "Toggle God Mode" "godmode"
 defaultbind KP5 "godmode"
 //IDKFA Hotkey
-alias allstuff "give IDKFAGiver"
+alias allstuff "give all; give IDKFAGiver"
 addmenukey "Give All" "allstuff"
 defaultbind KP7 "allstuff"
 //Level Warp Hotkey

--- a/decorate/DEC_CHEATS.dec
+++ b/decorate/DEC_CHEATS.dec
@@ -34,25 +34,6 @@ Actor IDKFAGiver : CustomInventory
 	Pickup:
 		TNT1 A 1 A_PlaySoundEx("cheat/idkfa", "Auto", 0, 0)
 		TNT1 A 1 A_Print("All Weapons, Ammo, Keys, and Armor!")
-		TNT1 A 1 A_GiveInventory("Backpack_TO", 1)
-		TNT1 A 1 A_GiveInventory("Chainsaw_TO", 1)
-		TNT1 A 1 A_GiveInventory("Shotgun_TO", 1)
-		TNT1 A 1 A_GiveInventory("SuperShotgun_TO", 1)
-		TNT1 A 1 A_GiveInventory("Chaingun_TO", 1)
-		TNT1 A 1 A_GiveInventory("RocketLauncher_TO", 1)
-		TNT1 A 1 A_GiveInventory("PlasmaRifle_TO", 1)
-		TNT1 A 1 A_GiveInventory("BFG9000_TO", 1)
-		TNT1 A 1 A_GiveInventory("RedCard", 1)
-		TNT1 A 1 A_GiveInventory("RedSkull", 1)
-		TNT1 A 1 A_GiveInventory("BlueCard", 1)
-		TNT1 A 1 A_GiveInventory("BlueSkull", 1)
-		TNT1 A 1 A_GiveInventory("YellowCard", 1)
-		TNT1 A 1 A_GiveInventory("YellowSkull", 1)
-		TNT1 A 1 A_GiveInventory("Clip", 400)
-		TNT1 A 1 A_GiveInventory("Shell", 100)
-		TNT1 A 1 A_GiveInventory("RocketAmmo", 100)
-		TNT1 A 1 A_GiveInventory("Cell", 600)
-		TNT1 A 1 A_GiveInventory("BlueArmor_TO", 1)
 		Stop
 		}
 }

--- a/decorate/Detectors/WallHit.dec
+++ b/decorate/Detectors/WallHit.dec
@@ -11,6 +11,7 @@ actor WallHit
     +NOTIMEFREEZE
     -NOGRAVITY
     +THRUGHOST
+	+BLOCKASPLAYER
     //+ActivatePCross
     SeeSound "null"
     DeathSound "misc/wallhit"

--- a/zscript/quickturn.zs
+++ b/zscript/quickturn.zs
@@ -14,7 +14,7 @@ Class Toby_QuickTurnItem : Inventory
 		If(!owner || !owner.player){Destroy(); Return;}
 		If(owner.player.turnticks>0 && owner.player.cmd.buttons & BT_TURN180 && !(owner.player.oldbuttons & BT_TURN180))
 		{
-			A_StartSound("misc/quickturn", CHAN_AUTO, CHANF_DEFAULT, 1.0, ATTN_NONE, 0, 0);
+			owner.A_StartSound("misc/quickturn", CHAN_AUTO, CHANF_DEFAULT, 1.0, ATTN_STATIC, 0, 0);
 		}
 	}
 }


### PR DESCRIPTION
UPDATES:
- Added fix to Jarewill's quick turn script.
- Updated IDKFA Quick Cheat; can be used universally with Toby guns, classic Doom, or any other weapon wad.
- Updated KEYCONF
- Updated Impact Detection impact object; added flag +BLOCKASPLAYER; Impact Detection System will now be able to work on impassible linedefs with mid-textures (ie: metal bars, grates, etc.)