### PR TITLE
Add item checker

### DIFF
--- a/KEYCONF.txt
+++ b/KEYCONF.txt
@@ -27,6 +27,8 @@ addmenukey "Check Ammo Stats" "netevent Toby_CheckAmmo"
 defaultbind B "netevent Toby_CheckAmmo"
 addmenukey "Check Keys" "netevent Toby_CheckKeys"
 defaultbind K "netevent Toby_CheckKeys"
+addmenukey "Check current item" "netevent Toby_CheckCurrentItem"
+defaultbind I "netevent Toby_CheckCurrentItem"
 
 
 //God Mode Hotkey

--- a/zscript.zs
+++ b/zscript.zs
@@ -17,6 +17,7 @@ version "4.6"
 #include "zscript/StatusChecker/Toby_AmmoChecker.zs"
 #include "zscript/StatusChecker/Toby_KeyChecker.zs"
 #include "zscript/StatusChecker/Toby_ArmorChecker.zs"
+#include "zscript/StatusChecker/Toby_CurrentItemChecker.zs"
 #include "zscript/StatusChecker/Toby_PlayerStatusCheckStaticHandler.zs"
 
 //Weapon/item selection narration

--- a/zscript/SelectionNarration/Toby_SelectionNarrationHandler.zs
+++ b/zscript/SelectionNarration/Toby_SelectionNarrationHandler.zs
@@ -66,6 +66,8 @@ class Toby_SelectionNarrationHandler : EventHandler
         for (int i = 0; i < maxPlayers; i++)
         {
             if (!players[i].mo) { continue; }
+            if (!players[i].mo.player) { continue; }
+            if (!players[i].mo.player.ReadyWeapon) { continue; }
             string currentWeapon = players[i].mo.player.ReadyWeapon.GetClassName();
             if (currentWeapon == previousWeapon[i]) { continue; }
             if (previousWeapon[i] == "")

--- a/zscript/SoundBindings/Toby_ItemNameSoundBindings.txt
+++ b/zscript/SoundBindings/Toby_ItemNameSoundBindings.txt
@@ -1,0 +1,2 @@
+//Expected format:
+//{"ActorClass":"<class name>", "SoundToPlay":"<SNDINFO definition>"}

--- a/zscript/StatusChecker/Toby_CurrentItemChecker.zs
+++ b/zscript/StatusChecker/Toby_CurrentItemChecker.zs
@@ -1,0 +1,15 @@
+class Toby_CurrentItemChecker
+{
+    ui static void CheckCurrentItem(PlayerInfo player, Toby_SoundBindingsContainer bindings)
+    {
+        if (!player) { return; }
+        if (!player.mo) { return; }
+        string currentItem = "";
+        int amount = 0;
+        if (!player.mo.InvSel) { return; }
+        Inventory inv = player.mo.InvSel;
+        currentItem = inv.GetClassName();
+        amount = inv.amount;
+        Toby_SelectionNarrator.NarrateItemName(currentItem, amount, bindings);
+    }
+}

--- a/zscript/StatusChecker/Toby_PlayerStatusCheckStaticHandler.zs
+++ b/zscript/StatusChecker/Toby_PlayerStatusCheckStaticHandler.zs
@@ -49,6 +49,10 @@ class Toby_PlayerStatusCheckStaticHandler: StaticEventHandler
         {
             Toby_KeyChecker.CheckKeys(player, bindings.keysSoundBindingsContainer);
         }
+        if (e.Name == "Toby_CheckCurrentItemInterface")
+        {
+            Toby_CurrentItemChecker.CheckCurrentItem(player, bindings.itemsSoundBindingsContainer);
+        }
     }
 
     //Is this stupid?
@@ -72,6 +76,10 @@ class Toby_PlayerStatusCheckStaticHandler: StaticEventHandler
         if (e.Name == "Toby_CheckKeys")
         {
             EventHandler.SendInterfaceEvent(e.Player, "Toby_CheckKeysInterface");
+        }
+        if (e.Name == "Toby_CheckCurrentItem")
+        {
+            EventHandler.SendInterfaceEvent(e.Player, "Toby_CheckCurrentItemInterface");
         }
     }
 }


### PR DESCRIPTION
Added current item checker, default bind is `i`, feel free to change it to anything else.
Menu option for this key bind will require narration.

As discussed earlier this should cover the case where player has only one item type and wants to check what it is or how many of that single item they have.

For the rest of the cases just switching current inventory item should be enough.