### PR TITLE
Add coordinate checker

### DIFF
--- a/KEYCONF.txt
+++ b/KEYCONF.txt
@@ -20,6 +20,8 @@ defaultbind R "pukename TurnCompass 0"
 //Stat Checker - Health, Armor, Ammo, Keys
 
 addkeysection "Status Checker Options" CheckMod
+addmenukey "Check Coordinates" "netevent Toby_CheckCoordinates"
+defaultbind O "netevent Toby_CheckCoordinates"
 addmenukey "Check Health Stats" "netevent Toby_CheckHealth"
 addmenukey "Check Armor Stats" "netevent Toby_CheckArmor"
 defaultbind H "netevent Toby_CheckHealth"

--- a/zscript.zs
+++ b/zscript.zs
@@ -13,6 +13,7 @@ version "4.6"
 
 //Player status checker
 #include "zscript/StatusChecker/Toby_PlayerStatusCondition.zs"
+#include "zscript/StatusChecker/Toby_CoordinateChecker.zs"
 #include "zscript/StatusChecker/Toby_HealthChecker.zs"
 #include "zscript/StatusChecker/Toby_AmmoChecker.zs"
 #include "zscript/StatusChecker/Toby_KeyChecker.zs"

--- a/zscript/StatusChecker/Toby_CoordinateChecker.zs
+++ b/zscript/StatusChecker/Toby_CoordinateChecker.zs
@@ -1,0 +1,19 @@
+class Toby_CoordinateChecker
+{
+    ui static void CheckCoordinates(PlayerInfo player)
+    {
+        if (!player) { return; }
+        if (!player.mo) { return; }
+        Actor playerActor = player.mo;
+        Toby_NumberToSoundQueue numberToSoundQueue = Toby_NumberToSoundQueue.Create();
+        Toby_SoundQueueStaticHandler.AddSound("alphabet/X", -1);
+        Toby_SoundQueueStaticHandler.AddQueue(numberToSoundQueue.CreateQueueFromInt(playerActor.pos.x));
+        Toby_SoundQueueStaticHandler.AddSound("alphabet/Y", -1);
+        numberToSoundQueue.Reset();
+        Toby_SoundQueueStaticHandler.AddQueue(numberToSoundQueue.CreateQueueFromInt(playerActor.pos.y));
+        Toby_SoundQueueStaticHandler.AddSound("alphabet/Z", -1);
+        numberToSoundQueue.Reset();
+        Toby_SoundQueueStaticHandler.AddQueue(numberToSoundQueue.CreateQueueFromInt(playerActor.pos.z));
+        Toby_SoundQueueStaticHandler.PlayQueue(0);
+    }
+}

--- a/zscript/StatusChecker/Toby_PlayerStatusCheckStaticHandler.zs
+++ b/zscript/StatusChecker/Toby_PlayerStatusCheckStaticHandler.zs
@@ -19,6 +19,10 @@ class Toby_PlayerStatusCheckStaticHandler: StaticEventHandler
         PlayerInfo player = players[consoleplayer];
         if (!player) { return; }
         if (!player.mo) { return; }
+        if (e.Name == "Toby_CheckCoordinatesInterface")
+        {
+            Toby_CoordinateChecker.CheckCoordinates(player);
+        }
         if (e.Name == "Toby_CheckHealthInterface")
         {
             if (CVar.FindCvar("Toby_UseLegacyHealthChecker").GetBool())
@@ -57,6 +61,10 @@ class Toby_PlayerStatusCheckStaticHandler: StaticEventHandler
         PlayerInfo player = players[e.Player];
         if (!player) { return; }
         if (!player.mo) { return; }
+        if (e.Name == "Toby_CheckCoordinates")
+        {
+            EventHandler.SendInterfaceEvent(e.Player, "Toby_CheckCoordinatesInterface");
+        }
         if (e.Name == "Toby_CheckHealth")
         {
             EventHandler.SendInterfaceEvent(e.Player, "Toby_CheckHealthInterface");

--- a/zscript/Utils/SoundQueue/Toby_NumberToSoundQueue.zs
+++ b/zscript/Utils/SoundQueue/Toby_NumberToSoundQueue.zs
@@ -80,7 +80,7 @@ class Toby_NumberToSoundQueue
         int power = 0;
         bool hasMinus = false;
         string numberAsString = ""..number;
-        if (numberAsString.Mid(1,1) == "-")
+        if (numberAsString.Mid(0,1) == "-")
         {
             numberAsString = numberAsString.Mid(1, numberAsString.Length() - 1);
             hasMinus = true;


### PR DESCRIPTION
Implemented coordinate checker.
Uses alphabet to announce player position using following format:
`X: <integer number>, Y: <integer number>, Z: <integer number>`

Default bind is `o`, Menu option for this key bind will require narration.

Closes #73 