### PR TITLE
Reduce visual jitter of a pathfinding beacon

### DIFF
--- a/zscript/Pathfinder/Toby_PathfinderHandler.zs
+++ b/zscript/Pathfinder/Toby_PathfinderHandler.zs
@@ -91,11 +91,12 @@ class Toby_PathfinderHandler : EventHandler
                     if (nextNodeVector.Length() >= minDistance)
                     {
                         Vector3 newPos = playerActor.pos + nextNodeVector.Unit() * minDistance;
-                        pathfindingMarkers[i].SetOrigin(newPos, false);
+                        int zPos = Max(playerActor.GetZAt(newPos.x, newPos.y, 0, GZF_ABSOLUTEPOS), newPos.z);
+                        pathfindingMarkers[i].SetOrigin((newPos.xy, zPos), true);
                     }
                     else
                     {
-                        pathfindingMarkers[i].SetOrigin(currentNodeCurrent[i].pos, false);
+                        pathfindingMarkers[i].SetOrigin(currentNodeCurrent[i].pos, true);
                     }
                 }
             }


### PR DESCRIPTION
Spotted a small bug: beacon was jittering when player was lower than the floor beacon rests on.
Also enabled interpolation so that its less jittery in general.