### PR TITLE
Tiny Update

### DIFF
--- a/KEYCONF.txt
+++ b/KEYCONF.txt
@@ -21,7 +21,7 @@ defaultbind R "pukename TurnCompass 0"
 
 addkeysection "Status Checker Options" CheckMod
 addmenukey "Check Coordinates" "netevent Toby_CheckCoordinates"
-defaultbind O "netevent Toby_CheckCoordinates"
+defaultbind U "netevent Toby_CheckCoordinates"
 addmenukey "Check Health Stats" "netevent Toby_CheckHealth"
 addmenukey "Check Armor Stats" "netevent Toby_CheckArmor"
 defaultbind H "netevent Toby_CheckHealth"


### PR DESCRIPTION
Changed the hotkey for the Coordinate Checker. Figured to change it to "U" instead of "O."

I have O & P set to scroll the player's inventory left and right for Heretic.