### PR TITLE
Fix divistion by zero crash and slightly improve caching in Exploration

### DIFF
--- a/zscript/Pathfinder/Toby_InSectorNodeBuilder.zs
+++ b/zscript/Pathfinder/Toby_InSectorNodeBuilder.zs
@@ -18,10 +18,19 @@ class Toby_InSectorNodeBuilder
         // Sorry, I think we need to skip on caching
         // Or at least there should be a mechanism that would mark sectors as dirty
         // So that they could be recalculated instead of recalculating every time -PR
-        // if (sectorNodes[sectorId])
-        // {
-        //     return sectorNodes[sectorId];
-        // }
+
+        // Actually, I can make it a little bit better -PR
+        if (sectorNodes[sectorId])
+        {
+            Sector s = level.sectors[sectorId];
+            if (sectorNodes[sectorId].nodes.Size() < 0) { return sectorNodes[sectorId]; }
+            if (sectorNodes[sectorId].nodes[0].pos.z == s.CenterFloor()) { return sectorNodes[sectorId]; }
+            for (int i = 0; i < sectorNodes[sectorId].nodes.Size(); i++)
+            {
+                sectorNodes[sectorId].nodes[i].pos.z = s.CenterFloor();
+            }
+            return sectorNodes[sectorId];
+        }
         sectorNodes[sectorId] = BuildNodesForSector(sectorId, explorer);
         return sectorNodes[sectorId];
     }

--- a/zscript/Pathfinder/Toby_LineSegmentIntersectionUtil.zs
+++ b/zscript/Pathfinder/Toby_LineSegmentIntersectionUtil.zs
@@ -56,6 +56,7 @@ class Toby_LineSegmentIntersectionUtil
     static Vector2 ClosestPointOnSegment(Vector2 p, Vector2 a, Vector2 b)
     {
         Vector2 ab = b - a;
+        if (ab.Length() == 0) { return a; }
         Vector2 ap = p - a;
         double projectionScalar = (ap dot ab) / (ab.Length() * ab.Length());
         projectionScalar = Clamp(projectionScalar, 0, 1);


### PR DESCRIPTION
Somehow ID Software managed to create sector line with zero length 🙂