### PR TITLE
Add Toby_SnapToZeroPitch CVAR to cancel possible modded weapon recoil

### DIFF
--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -1,8 +1,9 @@
 server bool Toby_UniversalBeacon_UseUniversalSounds = false;
 server bool Toby_ZFootstepsEnabled = true;
 server bool Toby_NarratedCrouch = true;
+server bool Toby_SnapToZeroPitch = false;
 
-user int   zs_em_MaxDistance = 500;
+user int    zs_em_MaxDistance = 500;
 user bool   Toby_Developer = false;
 
 user bool   Toby_Developer_MenuEvents = false;

--- a/zscript/SnapToTarget/Toby_SnapToTargetHandler.zs
+++ b/zscript/SnapToTarget/Toby_SnapToTargetHandler.zs
@@ -5,10 +5,12 @@ class Toby_SnapToTargetHandler : EventHandler
     Array<int> snappingMode;
     int maxPlayers;
     float maxDistance;
+    bool playerSnappingToZeroPitch;
 
     override void OnRegister()
     {
         classIgnoreListLoader = Toby_ClassIgnoreListLoaderStaticHandler.GetInstance();
+        playerSnappingToZeroPitch = CVar.GetCVar("Toby_SnapToZeroPitch", players[consoleplayer]).GetBool();
     }
 
     override void WorldLoaded(WorldEvent e)
@@ -32,7 +34,19 @@ class Toby_SnapToTargetHandler : EventHandler
             Actor playerActor = players[i].mo;
             if (!playerActor) { continue; }
             SnapToNearestShootableActor(playerActor, i);
+            playerSnappingToZeroPitch = true;
+
         }
+        if (playerSnappingToZeroPitch)
+        {
+            for (i = 0; i < maxPlayers; i++)
+            {
+                Actor playerActor = players[i].mo;
+                if (!playerActor) { continue; }
+                SnapToZeroPitch(playerActor);
+            }
+        }
+
     }
 
     override void NetworkProcess(ConsoleEvent e)
@@ -63,6 +77,11 @@ class Toby_SnapToTargetHandler : EventHandler
         if (!closestActor) { return; }
         double angleToTarget = playerActor.AngleTo(closestActor);
         playerActor.A_SetAngle(angleToTarget, SPF_INTERPOLATE);
+    }
+
+    private void SnapToZeroPitch(Actor playerActor)
+    {
+        playerActor.A_SetPitch(0);
     }
 
     private Actor FindClosestShootableActor(Actor playerActor, Array<Actor> foundActors, float maxDistance)


### PR DESCRIPTION
I thought that some people may want to play with mods that have no setting for disabling recoil.
I'm adding a CVAR that will forcefully level player's view if enabled.