### PR TITLE
Fix exit sound binding

### DIFF
--- a/zscript/SoundBindings/Toby_MenuSoundBindings.txt
+++ b/zscript/SoundBindings/Toby_MenuSoundBindings.txt
@@ -658,7 +658,9 @@
 {"EventType":"OptionChanged", "CurrentMenuItemOptionName":"Marker 10", "SoundToPlay":"pathfinder/marker10"}
 
 {"EventType":"OptionChanged", "CurrentMenuItemOptionName":"Level start", "SoundToPlay":"pathfinder/levelstart"}
-{"EventType":"OptionChanged", "CurrentMenuItemOptionName":"Exit", "SoundToPlay":"pathfinder/exit"}
+{"EventType":"OptionChanged", "CurrentMenuName":"Toby_Marker_Pathfinding", "CurrentMenuItemOptionName":"Exit", "SoundToPlay":"pathfinder/exit"}
+{"EventType":"OptionChanged", "CurrentMenuName":"toby_marker_remove", "CurrentMenuItemOptionName":"Exit", "SoundToPlay":"pathfinder/exit"}
+{"EventType":"OptionChanged", "CurrentMenuName":"toby_marker_remove_nearest", "CurrentMenuItemOptionName":"Exit", "SoundToPlay":"pathfinder/exit"}
 {"EventType":"OptionChanged", "CurrentMenuItemOptionName":"Secret Exit", "SoundToPlay":"pathfinder/secretexit"}
 
 {"EventType":"OptionChanged", "CurrentMenuItemOptionName":"Red key door", "SoundToPlay":"pathfinder/reddoor"}

--- a/zscript/Utils/Toby_SoundBindingsContainer.zs
+++ b/zscript/Utils/Toby_SoundBindingsContainer.zs
@@ -26,9 +26,15 @@ class Toby_SoundBindingsContainer
 
                 //Replace sounds if exactly the same condition definition already exists:
                 Dictionary soundBinding = Dictionary.FromString(splitTokens[i]);
+                int newSoundBindingSize = Toby_SoundBindingsContainer.GetDictionarySize(soundBinding);
                 bool sameConditionFound = false;
                 for (int j = 0; j < container.soundBindings.Size(); j++)
                 {
+                    int existingBindingSize = Toby_SoundBindingsContainer.GetDictionarySize(container.soundBindings[j]);
+                    if (newSoundBindingSize != existingBindingSize)
+                    {
+                        continue;
+                    }
                     DictionaryIterator di = DictionaryIterator.Create(container.soundBindings[j]);
                     bool sameCondition = true;
                     while (di.Next())
@@ -60,5 +66,16 @@ class Toby_SoundBindingsContainer
             Toby_Logger.Message("Sound bindings added: "..container.soundBindings.Size(), "Toby_Developer");
         }
         return container;
+    }
+
+    static ui int GetDictionarySize(Dictionary d)
+    {
+        int size = 0;
+        DictionaryIterator di = DictionaryIterator.Create(d);
+        while (di.Next())
+        {
+            size++;
+        }
+        return size;
     }
 }


### PR DESCRIPTION
> There is one thing I did notice while testing, though. In Pathfinder, when the Exit is added to the list, the announcer, for some reason, is not announcing/saying "Exit" when the cursor is highlighting it. I'm not sure why, but if you are able to investigate it, that would be great. I feel there may be something in the Sound Bindings but I can't seem to see where the issue may be. Thank you in advance :)

_Originally posted by @Alando1-doom in https://github.com/Alando1-doom/Toby-Accessibility-Mod-for-Doom/issues/215#issuecomment-3116060727_

This one was a tough one to find.
Basically when I've devised sound bindings system I've added a mechanism that we don't utilize:
An ability to overwrite old sound bindings with a new ones.
For cases where you would want to translate the mod for example but you don't want to modify the core mod itself. You just override old bindings with new ones in a separate mod file.

But it had a flaw. From the point of view of this system those two conditions were the same:
```
{"EventType":"OptionChanged", "CurrentMenuItemOptionName":"Exit", "SoundToPlay":"pathfinder/exit"}
{"EventType":"OptionChanged", "CurrentMenuName":"InteractiveSounds", "CurrentMenuItemOptionName":"Exit", "SoundToPlay":"toby/actorsinviewport/env/exit"}
```
And since the second one if further down in the list it superseded the old one.
So it went: Okay, `CurrentMenuItemOptionName` is `Exit` **BUT** since we're not in `InteractiveSounds` menu its clearly the wrong sound binding, skipping this one.

I've added dumb check on dictionary size. Should fix the issue.
~But be aware that it will now trigger wrong sound in "InteractiveSounds".~
Actually... I've created 3 separate bindings for "Exit" to avoid that. Could also move it down the list, that would work too.