### PR TITLE
Sort weapons by slot

### DIFF
--- a/KEYCONF.txt
+++ b/KEYCONF.txt
@@ -106,5 +106,5 @@ AddMenuKey "Toggle elevation tone" toby_elevation_toggle_keybind
 addkeysection "Chessboard Coordinates System" ChessboardCoordinates
 alias toby_chessboard_toggle_keybind "netevent Toby_ChessboardCoordinatesToggle";
 alias toby_chessboard_check_keybind "netevent Toby_CheckChessboardCoordinates";
-AddMenuKey "Toggle chessboard coordinates" toby_chessboard_toggle_keybind
-AddMenuKey "Check chessboard coordinates" toby_chessboard_check_keybind
+AddMenuKey "$TOBY_CHESSOBOARD_COORDINATES_TOGGLE" toby_chessboard_toggle_keybind
+AddMenuKey "$TOBY_CHESSOBOARD_COORDINATES_CHECK" toby_chessboard_check_keybind

--- a/zscript.zs
+++ b/zscript.zs
@@ -93,6 +93,8 @@ version "4.6"
 #include "zscript/AccessibleMenu/Toby_WeaponsMenuItem.zs"
 #include "zscript/AccessibleMenu/Toby_ItemsMenuItem.zs"
 #include "zscript/AccessibleMenu/Toby_WeaponAndItemMenuHandler.zs"
+#include "zscript/AccessibleMenu/WeaponsMenu/Toby_WeaponSlotItem.zs"
+#include "zscript/AccessibleMenu/WeaponsMenu/Toby_WeaponSlotItemCollection.zs"
 
 //Utils
 #include "zscript/Utils/Toby_SoundBindingsContainer.zs"
@@ -103,6 +105,8 @@ version "4.6"
 #include "zscript/Utils/Toby_Enums.zs"
 #include "zscript/Utils/Toby_IntegerSet.zs"
 #include "zscript/Utils/Toby_Math.zs"
+#include "zscript/Utils/Sorting/Toby_SortableCollection.zs"
+#include "zscript/Utils/Sorting/Toby_QuickSort.zs"
 
 //libeye
 #include "zscript/libeye/Toby_projector gl.zs"

--- a/zscript/AccessibleMenu/Toby_WeaponsMenu.zs
+++ b/zscript/AccessibleMenu/Toby_WeaponsMenu.zs
@@ -10,7 +10,7 @@ class Toby_WeaponsMenu : OptionMenu
         Actor playerActor = player.mo;
         if (!playerActor) { return; }
 
-        Array<class<Weapon> > playerWeaponClasses;
+        Toby_WeaponSlotItemCollection weaponCollection = Toby_WeaponSlotItemCollection.Create();
 
         // This piece lifted directly from m8f's Gearbox
         for (int i = 0; i < AllActorClasses.Size(); ++i)
@@ -26,32 +26,35 @@ class Toby_WeaponsMenu : OptionMenu
 
             if (!located) { continue; };
 
-            readonly<Weapon> def = GetDefaultByType(type);
-            // Can't run from UI context :|
-            // if (!def.CanPickup(player.mo)) { continue; };
-
-            playerWeaponClasses.push(type);
+            weaponCollection.AddItem(slot, priority, type);
         }
 
-        for (int i = 0; i < playerWeaponClasses.Size(); i++)
+        Toby_QuickSort.QuickSort(weaponCollection, 0, weaponCollection.Size() - 1);
+
+        for (int i = 0; i < weaponCollection.Size(); i++)
         {
-            string className = playerWeaponClasses[i].GetClassName();
+            Toby_WeaponSlotItem item = (Toby_WeaponSlotItem)(weaponCollection.GetObject(i));
+            string className = item.type.GetClassName();
             Weapon playerWeapon = (Weapon)(playerActor.findInventory(className));
             if (!playerWeapon) { continue; }
 
-            string label = Toby_AmmoChecker.GetWeaponAndAmmoInfoString(playerActor, playerWeapon);
+            string label = item.slot .. ". " .. Toby_AmmoChecker.GetWeaponAndAmmoInfoString(playerActor, playerWeapon);
             string command = className;
 
             Toby_WeaponsMenuItem menuItem = (Toby_WeaponsMenuItem)(new("Toby_WeaponsMenuItem").Init(label, command));
 
             Toby_SoundBindingsLoaderStaticHandler bindings = Toby_SoundBindingsLoaderStaticHandler.GetInstance();
-            Toby_SoundQueue queue = Toby_AmmoChecker.GetWeaponAndAmmoSoundQueue(
+            Toby_SoundQueue weaponAndAmmoQueue = Toby_AmmoChecker.GetWeaponAndAmmoSoundQueue(
                 playerActor,
                 playerWeapon,
                 bindings.weaponsSoundBindingsContainer,
                 bindings.ammoSoundBindingsContainer
             );
-            menuItem.SetSoundQueue(queue);
+            Toby_NumberToSoundQueue slotNumberQueue = Toby_NumberToSoundQueue.Create();
+            Toby_SoundQueue finalQueue = Toby_SoundQueue.Create();
+            finalQueue.AddQueue(slotNumberQueue.CreateQueueFromInt(item.slot));
+            finalQueue.AddQueue(weaponAndAmmoQueue);
+            menuItem.SetSoundQueue(finalQueue);
 
             mDesc.mItems.Push(menuItem);
         }

--- a/zscript/AccessibleMenu/Toby_WeaponsMenu.zs
+++ b/zscript/AccessibleMenu/Toby_WeaponsMenu.zs
@@ -24,6 +24,11 @@ class Toby_WeaponsMenu : OptionMenu
             int priority;
             [located, slot, priority] = player.weapons.LocateWeapon(type);
 
+            if (slot == 0)
+            {
+                slot = 10;
+            }
+
             if (!located) { continue; };
 
             weaponCollection.AddItem(slot, priority, type);

--- a/zscript/AccessibleMenu/WeaponsMenu/Toby_WeaponSlotItem.zs
+++ b/zscript/AccessibleMenu/WeaponsMenu/Toby_WeaponSlotItem.zs
@@ -1,0 +1,17 @@
+class Toby_WeaponSlotItem
+{
+    int slot;
+    int priority;
+    class<Weapon> type;
+
+    static Toby_WeaponSlotItem Create(int slot, int priority, class<Weapon> type)
+    {
+        Toby_WeaponSlotItem item = new("Toby_WeaponSlotItem");
+
+        item.slot = slot;
+        item.priority = priority;
+        item.type = type;
+
+        return item;
+    }
+}

--- a/zscript/AccessibleMenu/WeaponsMenu/Toby_WeaponSlotItemCollection.zs
+++ b/zscript/AccessibleMenu/WeaponsMenu/Toby_WeaponSlotItemCollection.zs
@@ -1,0 +1,59 @@
+class Toby_WeaponSlotItemCollection : Toby_SortableCollection
+{
+    Array<Toby_WeaponSlotItem> collection;
+
+    static Toby_WeaponSlotItemCollection Create()
+    {
+        return new("Toby_WeaponSlotItemCollection");
+    }
+
+    int Size()
+    {
+        return collection.Size();
+    }
+
+    void AddItem(int slot, int priority, class<Weapon> type)
+    {
+        collection.push(Toby_WeaponSlotItem.Create(slot, priority, type));
+    }
+
+    override Object GetObject(int arrayPos)
+    {
+        if (arrayPos < 0 || arrayPos >= collection.Size()) { return null; }
+
+        return collection[arrayPos];
+    }
+
+    override void SetObject(int arrayPos, Object item)
+    {
+        if (arrayPos < 0 || arrayPos >= collection.Size()) { return; }
+
+        collection[arrayPos] = (Toby_WeaponSlotItem)(item);
+    }
+
+    override int Compare(int arrayPos, int pivotPos)
+    {
+        if (arrayPos < 0 || arrayPos >= collection.Size()) { return 1; };
+        if (pivotPos < 0 || pivotPos >= collection.Size()) { return -1; };
+        if (collection[arrayPos] == null) { return 0; }
+        if (collection[pivotPos] == null) { return 0; }
+
+        if (collection[arrayPos].slot < collection[pivotPos].slot)
+        {
+            return -1;
+        }
+        if (collection[arrayPos].slot > collection[pivotPos].slot)
+        {
+            return 1;
+        }
+        if (collection[arrayPos].priority < collection[pivotPos].priority)
+        {
+            return 1;
+        }
+        if (collection[arrayPos].priority > collection[pivotPos].priority)
+        {
+            return -1;
+        }
+        return 0;
+    }
+}

--- a/zscript/Utils/Sorting/Toby_QuickSort.zs
+++ b/zscript/Utils/Sorting/Toby_QuickSort.zs
@@ -1,0 +1,24 @@
+class Toby_QuickSort
+{
+    static void QuickSort(Toby_SortableCollection container, int left, int right)
+    {
+        int i = left;
+        int j = right;
+        int pivotPos = (left + right) / 2;
+        while (i <= j)
+        {
+            while (container.Compare(i, pivotPos) < 0) { i++; };
+            while (container.Compare(j, pivotPos) > 0) { j--; };
+            if (i <= j)
+            {
+                Object tmp = container.GetObject(i);
+                container.SetObject(i, container.GetObject(j));
+                container.SetObject(j, tmp);
+                i++;
+                j--;
+            }
+        }
+        if (left < j) QuickSort(container, left, j);
+        if (i < right) QuickSort(container, i, right);
+    }
+}

--- a/zscript/Utils/Sorting/Toby_QuickSort.zs
+++ b/zscript/Utils/Sorting/Toby_QuickSort.zs
@@ -14,6 +14,17 @@ class Toby_QuickSort
                 Object tmp = container.GetObject(i);
                 container.SetObject(i, container.GetObject(j));
                 container.SetObject(j, tmp);
+
+                if (i == pivotPos)
+                {
+                    pivotPos = j;
+                }
+
+                else if (j == pivotPos)
+                {
+                    pivotPos = i;
+                }
+
                 i++;
                 j--;
             }

--- a/zscript/Utils/Sorting/Toby_SortableCollection.zs
+++ b/zscript/Utils/Sorting/Toby_SortableCollection.zs
@@ -1,0 +1,6 @@
+class Toby_SortableCollection abstract
+{
+    abstract Object GetObject(int arrayPos);
+    abstract void SetObject(int arrayPos, Object item);
+    abstract int Compare(int arrayPos, int pivotPos);
+}


### PR DESCRIPTION
Closes #225 - found an issue, I've used the wrong string in KEYCONF

Weapons are now sorted by slot and inside of a slot they are sorted by slot priority.
I've decided to not include the word "Slot" into narration but it might be confusing why same number is used in front of different weapons.
I've decided against preserving cursor position across re-opening menus because menu is regenerated every time and number of items in menu could change in an unexpected way, crashing the game.

We're missing narration for keybinds to open weapons and items menus.