### PR TITLE
Update 10-16-2025

### DIFF
--- a/DECORATE.dec
+++ b/DECORATE.dec
@@ -3,7 +3,7 @@
 #include decorate/DEC_IDKFA.dec
 #include decorate/DEC_KDOR.dec
 #include decorate/MarkerChecker.dec
-#include decorate/DEC_PUFF.dec
+//#include decorate/DEC_PUFF.dec
 //Player
 #include decorate/Detectors/FloorChecker.dec
 //#include decorate/Detectors/WalkThing.dec

--- a/decorate/DEC_BEAC.dec
+++ b/decorate/DEC_BEAC.dec
@@ -167,8 +167,12 @@ Actor BasicSwitchChecker : TobyBeaconBase
 
 Actor ShootableSwitchChecker : TobyBeaconBase
 {
+	Radius 8
+    Height 56
+	PainChance 255
     Tag "Shootable Switch"
 	+SHOOTABLE
+	+ALLOWPAIN
     States
     {
     Spawn:
@@ -190,8 +194,16 @@ Actor ShootableSwitchChecker : TobyBeaconBase
         TNT1 A 1 A_FaceTarget
         Goto Beacon
     Pain:
-        TNT1 A 1
-        TNT1 A 1 A_Pain
+        TNT1 A 2 A_UnsetShootable
+        TNT1 A 0 A_SpawnProjectile("ShootableSwitchActivator", 32, 0, 0, CMF_AIMDIRECTION | CMF_ABSOLUTEANGLE, 0, AAPTR_TARGET)
+		TNT1 A 0 A_SpawnProjectile("ShootableSwitchActivator", 32, 0, 45, CMF_AIMDIRECTION | CMF_ABSOLUTEANGLE, 0, AAPTR_TARGET)
+		TNT1 A 0 A_SpawnProjectile("ShootableSwitchActivator", 32, 0, 90, CMF_AIMDIRECTION | CMF_ABSOLUTEANGLE, 0, AAPTR_TARGET)
+		TNT1 A 0 A_SpawnProjectile("ShootableSwitchActivator", 32, 0, 135, CMF_AIMDIRECTION | CMF_ABSOLUTEANGLE, 0, AAPTR_TARGET)
+		TNT1 A 0 A_SpawnProjectile("ShootableSwitchActivator", 32, 0, 180, CMF_AIMDIRECTION | CMF_ABSOLUTEANGLE, 0, AAPTR_TARGET)
+		TNT1 A 0 A_SpawnProjectile("ShootableSwitchActivator", 32, 0, 225, CMF_AIMDIRECTION | CMF_ABSOLUTEANGLE, 0, AAPTR_TARGET)
+		TNT1 A 0 A_SpawnProjectile("ShootableSwitchActivator", 32, 0, 270, CMF_AIMDIRECTION | CMF_ABSOLUTEANGLE, 0, AAPTR_TARGET)
+		TNT1 AA 35
+		TNT1 A 2 A_SetShootable
         Goto Spawn
 	NoSight:
 		TNT1 A 1
@@ -205,6 +217,26 @@ Actor ShootableSwitchChecker : TobyBeaconBase
         TNT1 A 5
         Stop
     }
+}
+
+
+ACTOR ShootableSwitchActivator //Projectile Released by Shootable Switch Beacon
+{
+	Radius 2
+	Height 2
+	Speed 10
+	Damage 0
+	Projectile
+	States
+	{
+	Spawn:
+		TNT1 A 10
+		Goto Death
+	Death:
+		TNT1 A 1
+		TNT1 A 35
+		Stop
+	}
 }
 
 //********************************************************


### PR DESCRIPTION
Tweaked the Shootable Switch Beacon and disabled the "THRUGHOST" Bullet Puff.

The Shootable Switch Beacon can be detected by the Targeter System and Auto-Aim. Tested the update using SIGIL. System works very well.

If there are any additional fixes/modifications needed, feel free to let me know.