### PR TITLE
Fix crash on load in Xim's Star Wars

### DIFF
--- a/zscript/StatusChecker/Toby_PlayerStatusCheckStaticHandler.zs
+++ b/zscript/StatusChecker/Toby_PlayerStatusCheckStaticHandler.zs
@@ -39,6 +39,7 @@ class Toby_PlayerStatusCheckStaticHandler: StaticEventHandler
             isNotFirstRun = true;
             bindings = Toby_SoundBindingsLoaderStaticHandler.GetInstance();
         }
+        if (chessboardCoords.Size() < maxPlayers) { return; }
         if (chessboardCoords[consoleplayer])
         {
             chessboardCoords[consoleplayer].AnnounceUpdates();


### PR DESCRIPTION
Xim's Star Wars crashes on load with array out of bounds reported from chessboard coordinates. This PR fixes it by skipping chessboard coordinates update if array size is smaller than maxPlayers (which would mean it is not initialized yet).