### PR TITLE
Stop monster contribution to line activation tracker

### DIFF
--- a/zscript/Pathfinder/Toby_PathfinderHandler.zs
+++ b/zscript/Pathfinder/Toby_PathfinderHandler.zs
@@ -84,6 +84,10 @@ class Toby_PathfinderHandler : EventHandler
 
     override void WorldLineActivated(WorldEvent e)
     {
+        if (Toby_LineUtil.IsRepeatable(e.ActivatedLine))
+        {
+            if (!(e.thing is "PlayerPawn")) { return; }
+        }
         lineInteractionTracker.ActivateLine(e.ActivatedLine.Index());
     }
 


### PR DESCRIPTION
Monsters can activate lines too. This makes it so that if monster has activated repeatable line it remains non-interacted for player.