### PR TITLE
Bug fix for #305

### DIFF
--- a/zscript/Pathfinder/Toby_InSectorNodeBuilder.zs
+++ b/zscript/Pathfinder/Toby_InSectorNodeBuilder.zs
@@ -23,7 +23,7 @@ class Toby_InSectorNodeBuilder
         if (sectorNodes[sectorId])
         {
             Sector s = level.sectors[sectorId];
-            if (sectorNodes[sectorId].nodes.Size() < 0) { return sectorNodes[sectorId]; }
+            if (sectorNodes[sectorId].nodes.Size() <= 0) { return sectorNodes[sectorId]; }
             if (sectorNodes[sectorId].nodes[0].pos.z == s.CenterFloor()) { return sectorNodes[sectorId]; }
             for (int i = 0; i < sectorNodes[sectorId].nodes.Size(); i++)
             {


### PR DESCRIPTION
I think this is the fix.

We're failing here:
```csharp
        if (sectorNodes[sectorId])
        {
            Sector s = level.sectors[sectorId];
            if (sectorNodes[sectorId].nodes.Size() < 0) { return sectorNodes[sectorId]; }
            if (sectorNodes[sectorId].nodes[0].pos.z == s.CenterFloor()) { return sectorNodes[sectorId]; } // On this line, with array index out of bounds
            for (int i = 0; i < sectorNodes[sectorId].nodes.Size(); i++)
            {
                sectorNodes[sectorId].nodes[i].pos.z = s.CenterFloor();
            }
            return sectorNodes[sectorId];
        }
```

But array size could never be less than zero. I think I was a little insane when I typed that. Changed it to less or equal.
Closes #305